### PR TITLE
fix: resolve 4.x validation/CI failures on main

### DIFF
--- a/resources.vnet.gateway.network.tf
+++ b/resources.vnet.gateway.network.tf
@@ -17,10 +17,13 @@ resource "azurerm_subnet" "vgw" {
 resource "azurerm_route_table" "vgw" {
   count = var.enable_route_table_creation ? 1 : 0
 
-  location                      = var.location
-  name                          = coalesce(var.route_table_name, "${local.virtual_network_gateway_name}-rt")
-  resource_group_name           = try(local.resource_group_name, var.existing_virtual_network_resource_group_name)
-  disable_bgp_route_propagation = !var.enable_route_table_bgp_route_propagation
+  location            = var.location
+  name                = coalesce(var.route_table_name, "${local.virtual_network_gateway_name}-rt")
+  resource_group_name = try(local.resource_group_name, var.existing_virtual_network_resource_group_name)
+  # azurerm 4.x renamed `disable_bgp_route_propagation` to `bgp_route_propagation_enabled`
+  # and inverted its semantics. The module variable is kept (preserves public API);
+  # we pass it through directly.
+  bgp_route_propagation_enabled = var.enable_route_table_bgp_route_propagation
   tags                          = local.default_tags
 }
 


### PR DESCRIPTION
Post-merge fix for CI failures introduced by Phase 1 4.x migration.

**Failing job:** Terraform Validate
**Root cause:** `azurerm_route_table.disable_bgp_route_propagation` was renamed to `bgp_route_propagation_enabled` (with inverted semantics) in azurerm provider 4.x.
**Fix:** Use the new attribute name and pass `var.enable_route_table_bgp_route_propagation` through directly. Public module API is unchanged.

Validated locally:
- `terraform fmt -recursive -check` ✅
- `terraform init -backend=false -upgrade` ✅
- `terraform validate` ✅ Success